### PR TITLE
Fix bug in dry air density calculation

### DIFF
--- a/Python/COARE3.5/meteo.py
+++ b/Python/COARE3.5/meteo.py
@@ -112,10 +112,10 @@ def rhod(t,p):
 
     """
     Rd = 287.058        # gas const for dry air in J/kg K
-    tk = t+273.15       # deg Kelvin
+    Tk = t+273.15       # deg Kelvin
     Pa = p*100          # Pascals
     Rdry = Pa/(Rd*Tk)   # dry air density, kg/m3
-    return Rd
+    return Rdry
 
 
 def grv(latitude):


### PR DESCRIPTION
There is a bug in `meteo.rhod` that causes the function to return the gas constant instead of the density.

This PR fixes it.

It doesn't seem like this function is used by the COARE algorithm, but nevertheless someone could use it directly from the meteo module and get an incorrect result.