### PR TITLE
Add missing hsbb variable to COARE3.6 test output headers

### DIFF
--- a/Python/COARE3.6/coare36vnWarm_et.py
+++ b/Python/COARE3.6/coare36vnWarm_et.py
@@ -431,7 +431,7 @@ if __name__ == '__main__':
     fnameA = os.path.join(path,'test_36_output_py_082022_withwavesinput_withwarmlayer.txt')
     A=coare36vnWarm_et(Jd, U, Zu, Tair, Zt, RH, Zq, P, Tsg, SW_dn, LW_dn, Lat, Lon, Zi, Rainrate, Ts_depth, Ss, None, None, zrf_u, zrf_t, zrf_q)
     fnameA = os.path.join(path,'test_36_output_py_082022_withnowavesinput_withwarmlayer.txt')
-    A_hdr = 'usr\ttau\thsb\thlb\thbb\thlwebb\ttsr\tqsr\tzo\tzot\tzoq\tCd\t'
+    A_hdr = 'usr\ttau\thsb\thlb\thbb\thsbb\thlwebb\ttsr\tqsr\tzo\tzot\tzoq\tCd\t'
     A_hdr += 'Ch\tCe\tL\tzeta\tdT_skinx\tdq_skinx\tdz_skin\tUrf\tTrf\tQrf\t'
     A_hdr += 'RHrf\tUrfN\tTrfN\tQrfN\tlw_net\tsw_net\tLe\trhoa\tUN\tU10\tU10N\t'
     A_hdr += 'Cdn_10\tChn_10\tCen_10\thrain\tQs\tEvap\tT10\tT10N\tQ10\tQ10N\tRH10\t'

--- a/Python/COARE3.6/coare36vn_zrf_et.py
+++ b/Python/COARE3.6/coare36vn_zrf_et.py
@@ -985,7 +985,7 @@ if __name__ == '__main__':
     fnameA = os.path.join(path,'test_36_output_py_082022_withwavesinput.txt')
     # A=coare36vn_zrf_et(u, zu , t, zt, rh, zq, P, ts, sw_dn, lw_dn, lat, lon,jd, zi,rain, Ss, None , None, zrf_u, zrf_t, zrf_q)
     # fnameA = os.path.join(path,'test_36_output_py_082022_withnowavesinput.txt')
-    A_hdr = 'usr\ttau\thsb\thlb\thbb\thlwebb\ttsr\tqsr\tzo\tzot\tzoq\tCd\t'
+    A_hdr = 'usr\ttau\thsb\thlb\thbb\thsbb\thlwebb\ttsr\tqsr\tzo\tzot\tzoq\tCd\t'
     A_hdr += 'Ch\tCe\tL\tzeta\tdT_skinx\tdq_skinx\tdz_skin\tUrf\tTrf\tQrf\t'
     A_hdr += 'RHrf\tUrfN\tTrfN\tQrfN\tlw_net\tsw_net\tLe\trhoa\tUN\tU10\tU10N\t'
     A_hdr += 'Cdn_10\tChn_10\tCen_10\thrain\tQs\tEvap\tT10\tT10N\tQ10\tQ10N\tRH10\t'


### PR DESCRIPTION
The header line for the test output text file, defined at the end of both `coare36vn_zrf_et.py` and `coare36vnWarm.py`, was missing the variable `hsbb`. According to the output from the `coare36vn_zrf_et` function, `hsbb `should appear between `hbb` and `hlwebb`. This update corrects the header to match the function output.